### PR TITLE
change wording for sandpaper components

### DIFF
--- a/index.qmd
+++ b/index.qmd
@@ -179,7 +179,7 @@ Two aspects:
 ::: {.column width="80%"}
 - The upcoming Carpentries lesson format is called [**"Workbench"**](https://carpentries.org/blog/2022/01/live-lesson-infrastructure/), developed by Zhian Kamvar
 
-- The Workbench format is based on **Rmarkdown** and **pandoc**
+- The Workbench format is based on **R** and **pandoc**-flavoured markdown
   - Rendering of lessons is **greatly simplified**
 
 :::{.fragment}


### PR DESCRIPTION
This is a minor detail, but sandpaper does not need to use RMarkdown. It uses the RMarkdown package under the hood to provide a stable, well-tested interface to pandoc after rendering markdown with knitr (if needed). In the future, we will likely replace RMarkdown with quarto.